### PR TITLE
Update __init__

### DIFF
--- a/TestlinkApiClient/__init__.py
+++ b/TestlinkApiClient/__init__.py
@@ -1,0 +1,1 @@
+from .tlxmlrpc import TestlinkClient


### PR DESCRIPTION
add import TestlinkClient to  __init__ so it is more straightforward to import in client code

```
from TestlinkApiClient.tlxmlrpc import TestlinkClient
```

becomes:

```
from TestlinkApiClient import TestlinkClient
```