### PR TITLE
update TestlinkApiClient/__init__.py imports

### DIFF
--- a/TestlinkApiClient/__init__.py
+++ b/TestlinkApiClient/__init__.py
@@ -1,0 +1,1 @@
+from .tlxmlrpc import TestlinkClient


### PR DESCRIPTION
add testlink client class to __init__ so imports are more straightforward

from TestlinkApiClient.tlxmlrpc import TestlinkClient

becomes:

from TestlinkApiClient import TestlinkClient